### PR TITLE
Pop errors

### DIFF
--- a/bin/popplot
+++ b/bin/popplot
@@ -76,12 +76,10 @@ def main():
 
     # read the amplitudes
     ns = max(inp['states']) + 1
-    amplitude = populations.total_amps(ndat_fnames, time, ns,
-                                       aconv=1./nseed)
+    amplitude = populations.total_amps(ndat_fnames, time, ns, aconv=1./nseed)
 
     # calculate bootstrap error
     if inp['calc_err']:
-        #aerr = np.std(nseed*amplitude, axis=0)
         avg, aerr = populations.error_amps(time, amplitude, ns,
                                            nboot=inp['n_bootstrap'],
                                            bthrsh=inp['boot_thrsh'])
@@ -104,9 +102,13 @@ def main():
     if inp['fit_function'] is not None:
         ff = inp['fit_function']
         examp = 1 - amplitude[0]
-        examp = (examp - min(examp)) / (max(examp) - min(examp))
+        if inp['calc_err']:
+            exerr = aerr[0]
+        else:
+            exerr = None
+
         opt, err = populations.fit_function(ff, time, examp, inp['p0'],
-                                            tconv=inp['time_conv'])
+                                            tconv=inp['time_conv'], err=exerr)
         populations.write_fit(ff, opt, err, inp['fit_data_name'])
         if inp['fit_plot_name'] is not None:
             t = time*inp['time_conv']

--- a/fmsinterpreter/default.py
+++ b/fmsinterpreter/default.py
@@ -118,7 +118,7 @@ popplot = dict(
     amplitude_err_name = 'pop.err',
     amplitude_plot_name = 'pop.pdf',
     fit_function = None,
-    p0 = [10, 50],
+    p0 = [10, 50, 0.1],
     fit_data_name = 'pop.fit',
     fit_plot_name = None
                )

--- a/fmsinterpreter/populations.py
+++ b/fmsinterpreter/populations.py
@@ -234,7 +234,7 @@ def thrsh_spawn_pop(amps, times, traj_info, inthrsh=5e-4, fithrsh=1e-4, nbuf=4):
     return pops
 
 
-def fit_function(func, times, decay, p0, tconv=1., err=None):
+def fit_function(func, times, decay, p0, tconv=1., err=None, ethrsh=1e-5):
     """Fits amplitudes to a given exponential decay function.
 
     For now, this is just fitting the return to the ground state. With
@@ -242,7 +242,7 @@ def fit_function(func, times, decay, p0, tconv=1., err=None):
     state or combination of states (e.g. 'S1 + S2').
     """
     if err is not None:
-        mask = err > 1e-5
+        mask = err > ethrsh
         err = err[mask]
         times = times[mask]
         decay = decay[mask]

--- a/fmsinterpreter/populations.py
+++ b/fmsinterpreter/populations.py
@@ -234,17 +234,24 @@ def thrsh_spawn_pop(amps, times, traj_info, inthrsh=5e-4, fithrsh=1e-4, nbuf=4):
     return pops
 
 
-def fit_function(func, times, decay, p0, tconv=1.):
+def fit_function(func, times, decay, p0, tconv=1., err=None):
     """Fits amplitudes to a given exponential decay function.
 
     For now, this is just fitting the return to the ground state. With
     some sort of string parsing it could be changed to accept any
     state or combination of states (e.g. 'S1 + S2').
     """
-    #decay = 1 - amps[0]
-    #decay = (decay - min(decay)) / (max(decay) - min(decay))
+    if err is not None:
+        mask = err > 1e-5
+        err = err[mask]
+        times = times[mask]
+        decay = decay[mask]
+        abssig = True
+    else:
+        abssig = False
     t = times * tconv
-    popt, pcov = curve_fit(globals()[func], t, decay, p0=p0)
+    popt, pcov = curve_fit(globals()[func], t, decay, p0=p0, sigma=err,
+                           absolute_sigma=abssig)
     perr = np.sqrt(np.diag(pcov))
 
     return popt, perr
@@ -257,6 +264,8 @@ def write_fit(func, popt, perr, outfname):
     """
     if func == 'exp':
         fitvals = ['t0', 'tau1']
+    if func == 'expc':
+        fitvals = ['t0', 'tau1', 'c']
     elif func == 'biexp':
         fitvals = ['t0', 'amp1', 'tau1', 'amp2', 'tau2']
     elif func == 'triexp':
@@ -274,6 +283,12 @@ def write_fit(func, popt, perr, outfname):
 def exp(x, x0, b):
     """Returns an exponential function for curve fitting purposes."""
     return np.exp(-(x - x0) / b)
+
+
+def expc(x, x0, b, c):
+    """Returns an exponential function plus a constant for curve fitting
+    purposes."""
+    return np.exp(-(x - x0) / b) + c
 
 
 def biexp(x, x0, a1, b1, a2, b2):


### PR DESCRIPTION
Errors (e.g. bootstrap errors) can now be used with scipy.optimize.curve_fit during fitting. The errors of the fit parameters are appropriately scaled.

The default to scale populations to the range [0, 1] during fitting has been removed as it effects the fit parameters. Instead, an exponential plus a constant is now the default fit function.